### PR TITLE
wip fix clusterrolebinding

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.53.1
+version: 0.53.2
 appVersion: 1.22.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/rolebinding.yaml
+++ b/charts/cass-operator/templates/rolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.clusterScoped }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -11,7 +10,8 @@ roleRef:
   kind: ClusterRole
   name: {{ template "k8ssandra-common.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-  {{- else }}
+{{- if not .Values.global.clusterScoped }}
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: Role
   name: {{ template "k8ssandra-common.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-  {{- end }}
+{{- end }}


### PR DESCRIPTION
**What this PR does**:

Fix `clusterrolebinding` creation.

After PR #1657, the ClusterRole is now created unconditionally but its related ClusterRoleBinding is still created only if .Values.global.clusterScoped is true

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
